### PR TITLE
Add minimal Python port of BigBlueButton bot

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,20 @@
+# BigBlueButton Bot – Python Version
+
+This directory contains a minimal Python port of the BigBlueButton bot
+prototype.  It mirrors the structure of the Go code and implements a small
+subset of its functionality using idiomatic Python.
+
+## Usage
+
+```python
+from bbb_bot import Client
+
+client = Client.from_config("https://example.com/bigbluebutton/api/", "SECRET")
+client.create("demo", "Demo meeting", "moderator", "attendee")
+join_url = client.join("demo", "Bot", "moderator")
+print("Join URL:", join_url)
+client.end("demo", "moderator")
+```
+
+The Python version currently focuses on the HTTP API and does not yet replicate
+the WebSocket/DDD message pump logic from the Go implementation.

--- a/python/bbb_bot/__init__.py
+++ b/python/bbb_bot/__init__.py
@@ -1,0 +1,5 @@
+"""Python implementation of the BigBlueButton bot prototype."""
+from .api import ApiClient
+from .client import Client
+
+__all__ = ["ApiClient", "Client"]

--- a/python/bbb_bot/api.py
+++ b/python/bbb_bot/api.py
@@ -1,0 +1,101 @@
+"""Minimal BigBlueButton API client.
+
+This module ports a subset of the Go API helper from this repository into
+Python.  It focuses on constructing request URLs with the appropriate
+checksum and performing HTTP GET requests.  Only the actions required for a
+basic bot (``create``, ``join`` and ``end``) are implemented, but the class is
+extensible and mirrors the behaviour of the Go implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import urllib.parse
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import requests
+
+
+# Supported hashing algorithms
+SHA1 = "SHA1"
+SHA256 = "SHA256"
+
+
+@dataclass
+class ApiClient:
+    """Helper for interacting with the BigBlueButton HTTP API."""
+
+    url: str
+    secret: str
+    sha: str = SHA256
+
+    def __post_init__(self) -> None:
+        if not (self.url.startswith("http://") or self.url.startswith("https://")):
+            raise ValueError("url has the wrong format. It should look like https://example.com/api/")
+        if not self.url.endswith("/"):
+            self.url += "/"
+        if not self.url.endswith("api/"):
+            self.url += "api/"
+        if self.sha not in {SHA1, SHA256}:
+            self.sha = SHA256
+
+    # ------------------------------------------------------------------
+    # URL helpers
+    def _build_params(self, params: Dict[str, str]) -> str:
+        encoded = [
+            f"{urllib.parse.quote_plus(k)}={urllib.parse.quote_plus(v)}"
+            for k, v in params.items()
+        ]
+        return "&".join(encoded)
+
+    def _checksum(self, action: str, param_str: str) -> str:
+        data = f"{action}{param_str}{self.secret}".encode()
+        if self.sha == SHA1:
+            return hashlib.sha1(data).hexdigest()
+        return hashlib.sha256(data).hexdigest()
+
+    def build_url(self, action: str, params: Optional[Dict[str, str]] = None) -> str:
+        params = params or {}
+        param_str = self._build_params(params)
+        checksum = self._checksum(action, param_str)
+        if param_str:
+            return f"{self.url}{action}?{param_str}&checksum={checksum}"
+        return f"{self.url}{action}?checksum={checksum}"
+
+    # ------------------------------------------------------------------
+    # Request helpers
+    def _request(self, action: str, params: Dict[str, str]) -> ET.Element:
+        url = self.build_url(action, params)
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        return ET.fromstring(response.content)
+
+    # ------------------------------------------------------------------
+    # High level API methods
+    def create(self, meeting_id: str, name: str, moderator_pw: str, attendee_pw: str) -> ET.Element:
+        params = {
+            "meetingID": meeting_id,
+            "name": name,
+            "moderatorPW": moderator_pw,
+            "attendeePW": attendee_pw,
+        }
+        return self._request("create", params)
+
+    def end(self, meeting_id: str, password: str) -> ET.Element:
+        params = {"meetingID": meeting_id, "password": password}
+        return self._request("end", params)
+
+    def join(self, meeting_id: str, full_name: str, password: str) -> str:
+        params = {
+            "meetingID": meeting_id,
+            "fullName": full_name,
+            "password": password,
+        }
+        xml = self._request("join", params)
+        # The join API returns an URL element on success.
+        url = xml.findtext("url")
+        if not url:
+            raise RuntimeError("join response did not contain a URL")
+        return url

--- a/python/bbb_bot/client.py
+++ b/python/bbb_bot/client.py
@@ -1,0 +1,41 @@
+"""High level client that mirrors the Go ``Client`` type.
+
+The client wraps :class:`ApiClient` and exposes a small subset of the
+functionality offered by the Go implementation.  It is intended as a starting
+point for a more complete port and demonstrates how the Go design maps to
+Python.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .api import ApiClient
+
+
+@dataclass
+class Client:
+    """Represents a BigBlueButton client connection."""
+
+    api: ApiClient
+    join_url: Optional[str] = None
+
+    @classmethod
+    def from_config(cls, api_url: str, secret: str, sha: str = "SHA256") -> "Client":
+        return cls(ApiClient(api_url, secret, sha))
+
+    # ------------------------------------------------------------------
+    def create(self, meeting_id: str, name: str, moderator_pw: str, attendee_pw: str) -> None:
+        self.api.create(meeting_id, name, moderator_pw, attendee_pw)
+
+    def join(self, meeting_id: str, full_name: str, password: str) -> str:
+        self.join_url = self.api.join(meeting_id, full_name, password)
+        return self.join_url
+
+    def end(self, meeting_id: str, password: str) -> None:
+        self.api.end(meeting_id, password)
+
+    def leave(self) -> None:
+        """Placeholder for future WebSocket disconnect logic."""
+        self.join_url = None


### PR DESCRIPTION
## Summary
- Add python/ subdirectory containing a basic Python port of the BigBlueButton bot
- Implement ApiClient for BigBlueButton HTTP API requests
- Provide Client wrapper class and usage documentation

## Testing
- `python -m py_compile python/bbb_bot/*.py`
- `pip install requests` *(fails: `Tunnel connection failed: 403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_688dc47c9cac832ca5aefb71ea047f9c